### PR TITLE
fix: prevent subagent sessions from being trashed

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xeaser/opencode-obsidian-sync",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Sync OpenCode AI sessions to Obsidian as structured Markdown notes with auto-tagging and Dataview dashboards",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Sessions never found in OpenCode storage (subagent sessions from explore/librarian/sisyphus-junior) are now permanently protected from `pollForDeletions`
- `foundInStorage: boolean` tracker field distinguishes real sessions from subagent sessions
- Only sessions that were previously found in storage AND are now gone get trashed (after 3 consecutive failures)
- 27 tests passing (2 new tests added for subagent protection)

Fixes the root cause where the 3-strike system delayed but didn't prevent trashing of subagent sessions.